### PR TITLE
Updated per new API.

### DIFF
--- a/tests/engine/render/lod/overlay/model/isGroupCulled.js
+++ b/tests/engine/render/lod/overlay/model/isGroupCulled.js
@@ -1,6 +1,10 @@
+if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
+Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
+var autoTester = createAutoTester(Script.resolvePath("."));
+
 (function() { // BEGIN LOCAL_SCOPE
 
-Script.include("../../../../../utils/test_stage.js?raw=true");
+Script.include(autoTester.getUtilsRootPath() + "test_stage.js");
 
 // Add the test Cases
 var flags = { 


### PR DESCRIPTION
# Description
The idea behind the change is to use a fixed path to utils.  This allows moving tests up and down the folder hierarchy.